### PR TITLE
Add ability to select from available Android devices

### DIFF
--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -16,7 +16,8 @@ def select_option(options, input=input, prompt='> ', error="Invalid selection"):
     provides non-integer input, or an invalid integer), it prints an
     error message and prompts the user again.
 
-    :param options: A dictionary of options to present to the user.
+    :param options: A dictionary, or list of tuples, of options to present to
+        the user.
     :param input: The function to use to retrieve the user's input. This
         exists so that the user's input can be easily mocked during testing.
     :param prompt: The prompt to display to the user.
@@ -24,12 +25,15 @@ def select_option(options, input=input, prompt='> ', error="Invalid selection"):
         input.
     :returns: The key corresponding to the user's chosen option.
     """
-    ordered = list(
-        sorted(
-            options.items(),
-            key=operator.itemgetter(1)
+    if isinstance(options, dict):
+        ordered = list(
+            sorted(
+                options.items(),
+                key=operator.itemgetter(1)
+            )
         )
-    )
+    else:
+        ordered = options
 
     for i, (key, value) in enumerate(ordered, start=1):
         print('  {i}) {label}'.format(i=i, label=value))

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -117,3 +117,15 @@ class MissingToolError(BriefcaseCommandError):
                 tool=tool,
             )
         )
+
+
+class InvalidDeviceError(BriefcaseCommandError):
+    def __init__(self, id_type, device):
+        self.id_type = id_type
+        self.device = device
+        super().__init__(
+            "Invalid device {id_type} '{device}'".format(
+                id_type=id_type,
+                device=device,
+            )
+        )

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -305,6 +305,26 @@ class ADB:
         self.command = android_sdk.command
         self.device = device
 
+    def avd_name(self):
+        """Get the AVD name for the device.
+
+        :returns: The AVD name for the device; or ``None`` if the device isn't
+            an emulator
+        """
+        try:
+            output = self.run('emu', 'avd', 'name')
+            return output.split('\n')[0]
+        except subprocess.CalledProcessError as e:
+            # Status code 1 is a normal "it's not an emulator" error response
+            if e.returncode == 1:
+                return None
+            else:
+                raise BriefcaseCommandError(
+                    "Unable to interrogate AVD name of device {device}".format(
+                        device=self.device
+                    )
+                )
+
     def run(self, *arguments):
         """
         Run a command on a device using Android debug bridge, `adb`. The device

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -12,7 +12,7 @@ from briefcase.commands import (
 )
 from briefcase.config import BaseConfig
 from briefcase.console import select_option
-from briefcase.exceptions import BriefcaseCommandError
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.xcode import (
     DeviceState,
     get_device_state,
@@ -95,11 +95,8 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
 
             # We've iterated through all available iOS versions and
             # found no match; return an error.
-            raise BriefcaseCommandError(
-                "Invalid simulator UDID {udid}".format(
-                    udid=udid_or_device
-                )
-            )
+            raise InvalidDeviceError('device UDID', udid)
+
         except (ValueError, TypeError):
             # Provided value wasn't a UDID.
             # It must be a device or device+version
@@ -121,17 +118,9 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
                         device = devices[udid]
                         return udid, iOS_version, device
                     except KeyError:
-                        raise BriefcaseCommandError(
-                            "Invalid device name '{device}'".format(
-                                    device=device
-                                )
-                            )
+                        raise InvalidDeviceError('device name', device)
                 except KeyError:
-                    raise BriefcaseCommandError(
-                       "Invalid OS Version '{iOS_version}'".format(
-                            iOS_version=iOS_version
-                        )
-                    )
+                    raise InvalidDeviceError('iOS Version', iOS_version)
             elif udid_or_device:
                 # Just a device name
                 device = udid_or_device
@@ -155,11 +144,7 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
                     except KeyError:
                         # UDID doesn't exist in this iOS version; try another.
                         pass
-                raise BriefcaseCommandError(
-                    "Invalid device name '{device}'".format(
-                            device=device
-                        )
-                    )
+                raise InvalidDeviceError('device name', device)
 
         if len(simulators) == 0:
             raise BriefcaseCommandError(

--- a/tests/console/test_select_option.py
+++ b/tests/console/test_select_option.py
@@ -22,6 +22,26 @@ def test_select_option():
     assert result == 'second'
 
 
+def test_select_option_list():
+    "If select_option is given a list of tuples, they're presented as provided"
+    # Return '3' when prompted
+    mock_input = mock.MagicMock(return_value='3')
+
+    options = [
+        ('first', 'The first option'),
+        ('second', 'The second option'),
+        ('third', 'The third option'),
+        ('fourth', 'The fourth option'),
+    ]
+    result = select_option(options, input=mock_input)
+
+    # Input is requested once
+    assert mock_input.call_count == 1
+
+    # The third option is the third option :-)
+    assert result == 'third'
+
+
 def test_select_option_bad_input():
     # In order, return:
     #     blank

--- a/tests/integrations/android_sdk/ADB/test_avd_name.py
+++ b/tests/integrations/android_sdk/ADB/test_avd_name.py
@@ -1,0 +1,65 @@
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
+from briefcase.integrations.android_sdk import ADB
+
+
+def test_emulator(mock_sdk, capsys):
+    "Invoking `avd_name()` on an emulator returns the AVD."
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(return_value="exampledevice\nOK\n")
+
+    # Invoke avd_name
+    assert adb.avd_name() == 'exampledevice'
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("emu", "avd", "name")
+
+
+def test_device(mock_sdk, capsys):
+    "Invoking `avd_name()` on a device returns None."
+    # Mock out the adb response for a physical device
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(side_effect=subprocess.CalledProcessError(
+        returncode=1, cmd='emu avd name'
+    ))
+
+    # Invoke avd_name
+    assert adb.avd_name() is None
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("emu", "avd", "name")
+
+
+def test_adb_failure(mock_sdk, capsys):
+    "If `adb()` fails for a miscellaneous reason, an error is raised."
+    # Mock out the run command on an adb instance
+    adb = ADB(mock_sdk, "exampleDevice")
+    adb.run = MagicMock(side_effect=subprocess.CalledProcessError(
+        returncode=69, cmd='emu avd name'
+    ))
+
+    # Invoke install
+    with pytest.raises(BriefcaseCommandError):
+        adb.avd_name()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("emu", "avd", "name")
+
+
+def test_invalid_device(mock_sdk, capsys):
+    "Invoking `avd_name()` on an invalid device raises an error."
+    # Mock out the run command on an adb instance
+    adb = ADB(mock_sdk, "exampleDevice")
+    adb.run = MagicMock(side_effect=InvalidDeviceError('device', 'exampleDevice'))
+
+    # Invoke install
+    with pytest.raises(InvalidDeviceError):
+        adb.avd_name()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("emu", "avd", "name")

--- a/tests/integrations/android_sdk/ADB/test_command.py
+++ b/tests/integrations/android_sdk/ADB/test_command.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from briefcase.exceptions import BriefcaseCommandError
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.android_sdk import ADB
 
 
@@ -23,26 +23,27 @@ def test_simple_command(mock_sdk, tmp_path):
             "example",
             "command",
         ],
+        universal_newlines=True,
         stderr=subprocess.STDOUT,
     )
 
 
 @pytest.mark.parametrize(
-    "name, exception_text",
+    "name, exception",
     [
         # When the device is not found, look for a command the user can run to get a
         # list of valid devices.
-        ("device-not-found", "adb devices -l"),
+        ("device-not-found", InvalidDeviceError),
         # Validate that when an arbitrary adb errors, we print the full adb output.
         # This adb output comes from asking it to run a nonexistent adb command.
-        ("arbitrary-adb-error-unknown-command", "unknown command"),
+        ("arbitrary-adb-error-unknown-command", subprocess.CalledProcessError),
     ],
 )
-def test_error_handling(mock_sdk, tmp_path, name, exception_text):
+def test_error_handling(mock_sdk, tmp_path, name, exception):
     "ADB.command() can parse errors returned by adb."
     # Set up a mock command with a subprocess module that has with sample data loaded.
     adb_samples = Path(__file__).parent / "adb_errors"
-    with (adb_samples / (name + ".txt")).open("rb") as adb_output_file:
+    with (adb_samples / (name + ".txt")).open("r") as adb_output_file:
         with (adb_samples / (name + ".returncode")).open() as returncode_file:
             mock_sdk.command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
                 returncode=int(returncode_file.read().strip()),
@@ -52,7 +53,7 @@ def test_error_handling(mock_sdk, tmp_path, name, exception_text):
 
     # Create an ADB instance and invoke run()
     adb = ADB(mock_sdk, "exampleDevice")
-    with pytest.raises(BriefcaseCommandError) as exc_info:
+    with pytest.raises(exception):
         adb.run("example", "command")
 
     # Check that adb was invoked as expected
@@ -64,8 +65,6 @@ def test_error_handling(mock_sdk, tmp_path, name, exception_text):
             "example",
             "command",
         ],
+        universal_newlines=True,
         stderr=subprocess.STDOUT,
     )
-
-    # Look for the expected exception text.
-    assert exception_text in str(exc_info.value)

--- a/tests/integrations/android_sdk/ADB/test_command.py
+++ b/tests/integrations/android_sdk/ADB/test_command.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
+from briefcase.exceptions import InvalidDeviceError
 from briefcase.integrations.android_sdk import ADB
 
 

--- a/tests/integrations/android_sdk/ADB/test_force_stop_app.py
+++ b/tests/integrations/android_sdk/ADB/test_force_stop_app.py
@@ -1,5 +1,9 @@
+import subprocess
 from unittest.mock import MagicMock
 
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.android_sdk import ADB
 
 
@@ -7,7 +11,7 @@ def test_force_stop_app(mock_sdk, capsys):
     "Invoking `force_stop_app()` calls `run()` with the appropriate parameters."
     # Mock out the run command on an adb instance
     adb = ADB(mock_sdk, "exampleDevice")
-    adb.run = MagicMock(return_value=b"example normal adb output")
+    adb.run = MagicMock(return_value="example normal adb output")
 
     # Invoke force_stop_app
     adb.force_stop_app("com.example.sample.package")
@@ -20,3 +24,37 @@ def test_force_stop_app(mock_sdk, capsys):
     # Validate that the normal output of the command was not printed (since there
     # was no error).
     assert "normal adb output" not in capsys.readouterr()
+
+
+def test_force_top_fail(mock_sdk, capsys):
+    "If `force_stop_app()` fails, an error is raised."
+    # Mock out the run command on an adb instance
+    adb = ADB(mock_sdk, "exampleDevice")
+    adb.run = MagicMock(side_effect=subprocess.CalledProcessError(
+        returncode=69, cmd='force-stop'
+    ))
+
+    # Invoke force_stop_app
+    with pytest.raises(BriefcaseCommandError):
+        adb.force_stop_app("com.example.sample.package")
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with(
+        "shell", "am", "force-stop", "com.example.sample.package"
+    )
+
+
+def test_invalid_device(mock_sdk, capsys):
+    "Invoking `force_stop_app()` on an invalid device raises an error."
+    # Mock out the run command on an adb instance
+    adb = ADB(mock_sdk, "exampleDevice")
+    adb.run = MagicMock(side_effect=InvalidDeviceError('device', 'exampleDevice'))
+
+    # Invoke force_stop_app
+    with pytest.raises(InvalidDeviceError):
+        adb.force_stop_app("com.example.sample.package")
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with(
+        "shell", "am", "force-stop", "com.example.sample.package"
+    )

--- a/tests/integrations/android_sdk/ADB/test_install_apk.py
+++ b/tests/integrations/android_sdk/ADB/test_install_apk.py
@@ -1,5 +1,9 @@
+import subprocess
 from unittest.mock import MagicMock
 
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.android_sdk import ADB
 
 
@@ -7,7 +11,7 @@ def test_install_apk(mock_sdk, capsys):
     "Invoking `install_apk()` calls `run()` with the appropriate parameters."
     # Mock out the run command on an adb instance
     adb = ADB(mock_sdk, "exampleDevice")
-    adb.run = MagicMock(return_value=b"example normal adb output")
+    adb.run = MagicMock(return_value="example normal adb output")
 
     # Invoke install
     adb.install_apk("example.apk")
@@ -18,3 +22,33 @@ def test_install_apk(mock_sdk, capsys):
     # Validate that the normal output of the command was not printed (since there
     # was no error).
     assert "normal adb output" not in capsys.readouterr()
+
+
+def test_install_failure(mock_sdk, capsys):
+    "If `install_apk()` fails, an error is raised."
+    # Mock out the run command on an adb instance
+    adb = ADB(mock_sdk, "exampleDevice")
+    adb.run = MagicMock(side_effect=subprocess.CalledProcessError(
+        returncode=2, cmd='install'
+    ))
+
+    # Invoke install
+    with pytest.raises(BriefcaseCommandError):
+        adb.install_apk("example.apk")
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("install", "example.apk")
+
+
+def test_invalid_device(mock_sdk, capsys):
+    "Invoking `install_apk()` on an invalid device raises an error."
+    # Mock out the run command on an adb instance
+    adb = ADB(mock_sdk, "exampleDevice")
+    adb.run = MagicMock(side_effect=InvalidDeviceError('device', 'exampleDevice'))
+
+    # Invoke install
+    with pytest.raises(InvalidDeviceError):
+        adb.install_apk("example.apk")
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("install", "example.apk")

--- a/tests/integrations/android_sdk/ADB/test_start_app.py
+++ b/tests/integrations/android_sdk/ADB/test_start_app.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.exceptions import BriefcaseCommandError
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.android_sdk import ADB
 
 
@@ -10,7 +10,7 @@ def test_start_app_launches_app(mock_sdk, capsys):
     "Invoking `start_app()` calls `run()` with the appropriate parameters."
     # Mock out the run command on an adb instance
     adb = ADB(mock_sdk, "exampleDevice")
-    adb.run = MagicMock(return_value=b"example normal adb output")
+    adb.run = MagicMock(return_value="example normal adb output")
 
     # Invoke start_app
     adb.start_app("com.example.sample.package", "com.example.sample.activity")
@@ -37,7 +37,7 @@ def test_missing_activity(mock_sdk):
     # Use real `adb` output from launching an activity that does not exist.
     # Mock out the run command on an adb instance
     adb = ADB(mock_sdk, "exampleDevice")
-    adb.run = MagicMock(return_value=b"""\
+    adb.run = MagicMock(return_value="""\
 Starting: Intent { act=android.intent.action.MAIN cat=[android.intent.category.\
 LAUNCHER] cmp=com.example.sample.package/.MainActivity }
 Error type 3
@@ -49,3 +49,14 @@ MainActivity} does not exist.
         adb.start_app("com.example.sample.package", "com.example.sample.activity")
 
     assert "Activity class not found" in str(exc_info.value)
+
+
+def test_invalid_device(mock_sdk):
+    "If the device doesn't exist, the error is caught."
+    # Use real `adb` output from launching an activity that does not exist.
+    # Mock out the run command on an adb instance
+    adb = ADB(mock_sdk, "exampleDevice")
+    adb.run = MagicMock(side_effect=InvalidDeviceError('device', 'exampleDevice'))
+
+    with pytest.raises(InvalidDeviceError):
+        adb.start_app("com.example.sample.package", "com.example.sample.activity")

--- a/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
@@ -1,0 +1,5 @@
+List of devices attached
+041234567892009a       unauthorized usb:336675328X transport_id:2
+KABCDABCDA1513         device usb:336675584X product:Kogan_Agora_9 model:Kogan_Agora_9 device:Kogan_Agora_9 transport_id:1
+emulator-5554          device product:sdk_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:4
+

--- a/tests/integrations/android_sdk/AndroidSDK/devices/no_devices
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/no_devices
@@ -1,0 +1,2 @@
+List of devices attached
+

--- a/tests/integrations/android_sdk/AndroidSDK/devices/one_emulator
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/one_emulator
@@ -1,0 +1,3 @@
+List of devices attached
+emulator-5554          device product:sdk_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:4
+

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -22,7 +22,10 @@ def test_one_emulator(mock_sdk):
         mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
 
     assert mock_sdk.devices() == {
-        'emulator-5554': 'generic_x86'
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
     }
 
 
@@ -33,9 +36,18 @@ def test_multiple_devices(mock_sdk):
         mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
 
     assert mock_sdk.devices() == {
-        '041234567892009a': 'Unknown device (not authorized for development)',
-        'KABCDABCDA1513': 'Kogan_Agora_9',
-        'emulator-5554': 'generic_x86'
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
     }
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -1,0 +1,49 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+
+def test_no_devices(mock_sdk):
+    "If there are no devices, an empty list is returned"
+    adb_samples = Path(__file__).parent / "devices"
+    with (adb_samples / ("no_devices")).open("r") as adb_output_file:
+        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+
+    assert mock_sdk.devices() == {}
+
+
+def test_one_emulator(mock_sdk):
+    "If there is a single emulator, it is returned"
+    adb_samples = Path(__file__).parent / "devices"
+    with (adb_samples / ("one_emulator")).open("r") as adb_output_file:
+        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+
+    assert mock_sdk.devices() == {
+        'emulator-5554': 'generic_x86'
+    }
+
+
+def test_multiple_devices(mock_sdk):
+    "If there are multiple devices, they are all returned"
+    adb_samples = Path(__file__).parent / "devices"
+    with (adb_samples / ("multiple_devices")).open("r") as adb_output_file:
+        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+
+    assert mock_sdk.devices() == {
+        '041234567892009a': 'Unknown device (not authorized for development)',
+        'KABCDABCDA1513': 'Kogan_Agora_9',
+        'emulator-5554': 'generic_x86'
+    }
+
+
+def test_adb_error(mock_sdk):
+    "If there is a problem invoking adb, an error is returned"
+    mock_sdk.command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        returncode=69, cmd="adb devices -l"
+    )
+
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.devices()

--- a/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
@@ -1,0 +1,36 @@
+import subprocess
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+
+def test_no_emulators(mock_sdk):
+    "If there are no emulators, an empty list is returned"
+    mock_sdk.command.subprocess.check_output.return_value = ''
+
+    assert mock_sdk.emulators() == []
+
+
+def test_one_emulator(mock_sdk):
+    "If there is a single emulator, it is returned"
+    mock_sdk.command.subprocess.check_output.return_value = 'first\n'
+
+    assert mock_sdk.emulators() == ['first']
+
+
+def test_multiple_emulators(mock_sdk):
+    "If there are multiple emulators, they are all returned"
+    mock_sdk.command.subprocess.check_output.return_value = 'first\nsecond\nthird\n'
+
+    assert mock_sdk.emulators() == ['first', 'second', 'third']
+
+
+def test_adb_error(mock_sdk):
+    "If there is a problem invoking adb, an error is returned"
+    mock_sdk.command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        returncode=69, cmd="adb devices -l"
+    )
+
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.emulators()

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -3,7 +3,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import InvalidDeviceError
-from briefcase.integrations.android_sdk import AndroidSDK, AndroidDeviceNotAuthorized
+from briefcase.integrations.android_sdk import (
+    AndroidDeviceNotAuthorized,
+    AndroidSDK
+)
 
 
 @pytest.fixture

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -1,0 +1,220 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.exceptions import InvalidDeviceError
+from briefcase.integrations.android_sdk import AndroidSDK, AndroidDeviceNotAuthorized
+
+
+@pytest.fixture
+def mock_sdk(tmp_path):
+    command = MagicMock()
+    sdk = AndroidSDK(command, root_path=tmp_path)
+
+    sdk.devices = MagicMock(return_value={
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
+    })
+
+    sdk.emulators = MagicMock(return_value=[
+        'runningEmulator',
+        'idleEmulator',
+    ])
+
+    # Set up an ADB for each device.
+    def mock_adb(device_id):
+        adb = MagicMock()
+        if device_id == 'emulator-5554':
+            adb.avd_name.return_value = 'runningEmulator'
+        else:
+            adb.avd_name.return_value = None
+        return adb
+
+    sdk.adb = mock_adb
+
+    return sdk
+
+
+def test_explicit_device(mock_sdk):
+    "If the user explicitly names a physical device, it is returned"
+
+    # Select device with an explicit device ID
+    device, name, avd = mock_sdk.select_target_device('KABCDABCDA1513')
+
+    # Physical running device, so no AVD
+    assert device == 'KABCDABCDA1513'
+    assert name == 'Kogan_Agora_9'
+    assert avd is None
+
+    # No input was requested
+    assert mock_sdk.command.input.call_count == 0
+
+
+def test_explicit_unauthorized_device(mock_sdk):
+    "If the user explicitly names an unauthorized physical device, an error is raised"
+
+    # Select unauthorized device with an explicit device ID
+    with pytest.raises(AndroidDeviceNotAuthorized):
+        mock_sdk.select_target_device('041234567892009a')
+
+    # No input was requested
+    assert mock_sdk.command.input.call_count == 0
+
+
+def test_explicit_running_emulator_by_id(mock_sdk):
+    "If the user explicitly names a running emulator by device ID, it is selected"
+
+    # Select emulator with an explicit device ID
+    device, name, avd = mock_sdk.select_target_device('emulator-5554')
+
+    # Emulator is running, so there is a device ID
+    assert device == 'emulator-5554'
+    assert name == '@runningEmulator (running generic_x86 emulator)'
+    assert avd == "runningEmulator"
+
+    # No input was requested
+    assert mock_sdk.command.input.call_count == 0
+
+
+def test_explicit_running_emulator_by_avd(mock_sdk):
+    "If the user explicitly names a running emulator by AVD, it is selected"
+
+    # Select emulator with an explicit device ID
+    device, name, avd = mock_sdk.select_target_device('@runningEmulator')
+
+    # Emulator is running, so there is a device ID
+    assert device == 'emulator-5554'
+    assert name == '@runningEmulator (running generic_x86 emulator)'
+    assert avd == "runningEmulator"
+
+    # No input was requested
+    assert mock_sdk.command.input.call_count == 0
+
+
+def test_explicit_idle_emulator(mock_sdk):
+    "If the user explicitly names an idle emulator by AVD, it is selected"
+
+    # Select emulator with an explicit device ID
+    device, name, avd = mock_sdk.select_target_device('@idleEmulator')
+
+    # Emulator is not running, so no device ID
+    assert device is None
+    assert name == '@idleEmulator (emulator)'
+    assert avd == 'idleEmulator'
+
+    # No input was requested
+    assert mock_sdk.command.input.call_count == 0
+
+
+def test_explicit_invalid_device(mock_sdk):
+    "If the user explicitly names a non-existet device, an error is raised"
+
+    # Select emulator with an invalid device ID
+    with pytest.raises(InvalidDeviceError):
+        device, name, avd = mock_sdk.select_target_device('deadbeefcafe')
+
+    # No input was requested
+    assert mock_sdk.command.input.call_count == 0
+
+
+def test_explicit_invalid_avd(mock_sdk):
+    "If the user explicitly names a non-existent device, an error is raised"
+
+    # Select emulator with an invalid AVD
+    with pytest.raises(InvalidDeviceError):
+        device, name, avd = mock_sdk.select_target_device('@invalidEmulator')
+
+    # No input was requested
+    assert mock_sdk.command.input.call_count == 0
+
+
+def test_select_device(mock_sdk, capsys):
+    "If the user manually selects a physical device, details are returned"
+    # Mock the user input
+    mock_sdk.command.input.return_value = 1
+
+    # Run the selection with no pre-existing choice
+    device, name, avd = mock_sdk.select_target_device(None)
+
+    # Physical running device, so no AVD
+    assert device == 'KABCDABCDA1513'
+    assert name == 'Kogan_Agora_9'
+    assert avd is None
+
+    # A re-run prompt has been provided
+    out = capsys.readouterr().out
+    assert "briefcase run android -d KABCDABCDA1513" in out
+
+
+def test_select_unauthorized_device(mock_sdk):
+    "If the user manually selects an unauthorized running device, an error is raised"
+    # Mock the user input
+    mock_sdk.command.input.return_value = 2
+
+    # Run the selection with no pre-existing choice
+    with pytest.raises(AndroidDeviceNotAuthorized):
+        mock_sdk.select_target_device(None)
+
+
+def test_select_running_emulator(mock_sdk, capsys):
+    "If the user manually selects a running emulator, details are returned"
+    # Mock the user input
+    mock_sdk.command.input.return_value = 3
+
+    # Run the selection with no pre-existing choice
+    device, name, avd = mock_sdk.select_target_device(None)
+
+    # Emulator is running, so there is a device ID
+    assert device == 'emulator-5554'
+    assert name == '@runningEmulator (running generic_x86 emulator)'
+    assert avd == "runningEmulator"
+
+    # A re-run prompt has been provided
+    out = capsys.readouterr().out
+    assert "briefcase run android -d @runningEmulator" in out
+
+
+def test_select_idle_emulator(mock_sdk, capsys):
+    "If the user manually selects a running device, details are returned"
+    # Mock the user input
+    mock_sdk.command.input.return_value = 4
+
+    # Run the selection with no pre-existing choice
+    device, name, avd = mock_sdk.select_target_device(None)
+
+    # Emulator is not running, so no device ID
+    assert device is None
+    assert name == '@idleEmulator (emulator)'
+    assert avd == 'idleEmulator'
+
+    # A re-run prompt has been provided
+    out = capsys.readouterr().out
+    assert "briefcase run android -d @idleEmulator" in out
+
+
+def test_select_create_emulator(mock_sdk, capsys):
+    "If the user manually selects a running device, details are returned"
+    # Mock the user input
+    mock_sdk.command.input.return_value = 5
+
+    # Run the selection with no pre-existing choice
+    device, name, avd = mock_sdk.select_target_device(None)
+
+    # No device details
+    assert device is None
+    assert name is None
+    assert avd is None
+
+    # A re-run prompt has *not* been provided
+    out = capsys.readouterr().out
+    assert "In future, you could specify this device" not in out

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
+from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.platforms.android.gradle import GradleRunCommand
 
 
@@ -13,8 +14,8 @@ def run_command(tmp_path, first_app_config):
     command.java_home_path = tmp_path / "java"
 
     command.mock_adb = MagicMock()
-    command.android_sdk = MagicMock()
-    command.android_sdk.adb.return_value = command.mock_adb
+    command.android_sdk = AndroidSDK(command, root_path=tmp_path)
+    command.android_sdk.adb = MagicMock(return_value=command.mock_adb)
 
     command.os = MagicMock()
     command.os.environ = {}
@@ -24,23 +25,23 @@ def run_command(tmp_path, first_app_config):
     return command
 
 
-def test_run_app_requires_device_name(run_command, first_app_config):
-    """`run_app()` raises an exception if the user does not specify an Android device."""
+def test_run_existing_device(run_command, first_app_config):
+    "An app can be run on an existing device"
+    # Set up device selection to return a running physical device.
+    run_command.android_sdk.select_target_device = MagicMock(
+        return_value=("exampleDevice", 'ExampleDevice', None)
+    )
 
-    with pytest.raises(BriefcaseCommandError):
-        run_command.run_app(first_app_config)
-
-    # The ADB wrapper wasn't even created
-    run_command.mock_adb.assert_not_called()
-
-
-def test_run_app_launches_app_properly(run_command, first_app_config):
-    """`run_app()` calls the appropriate `adb` integration commands."""
     # Invoke run_app
-    run_command.run_app(first_app_config, "exampleDevice")
+    run_command.run_app(first_app_config, device_or_avd="exampleDevice")
+
+    # selecte_target_device was invoked with a specific device
+    run_command.android_sdk.select_target_device.assert_called_once_with(
+        device_or_avd="exampleDevice"
+    )
 
     # The ADB wrapper is created
-    run_command.android_sdk.adb.assert_called_once_with(run_command, device="exampleDevice")
+    run_command.android_sdk.adb.assert_called_once_with(device="exampleDevice")
 
     # The adb wrapper is invoked with the expected arguments
     run_command.mock_adb.install_apk.assert_called_once_with(
@@ -57,3 +58,33 @@ def test_run_app_launches_app_properly(run_command, first_app_config):
         ),
         "org.beeware.android.MainActivity",
     )
+
+
+def test_run_created_device(run_command, first_app_config):
+    "If the user chooses to run on a newly created device, an error is raised (for now)"
+    # Set up device selection to return a completely new device
+    run_command.android_sdk.select_target_device = MagicMock(
+        return_value=(None, None, None)
+    )
+    run_command.input = MagicMock(return_value='newDevice')
+
+    with pytest.raises(BriefcaseCommandError):
+        run_command.run_app(first_app_config)
+
+    # The ADB wrapper wasn't even created
+    run_command.mock_adb.assert_not_called()
+
+
+def test_run_idle_device(run_command, first_app_config):
+    "If the user chooses to run on an idle device, an error is raised (for now)"
+    # Set up device selection to return a new device that has an AVD,
+    # but not a device ID.
+    run_command.android_sdk.select_target_device = MagicMock(
+        return_value=(None, "exampleDevice", "exampleDevice")
+    )
+
+    with pytest.raises(BriefcaseCommandError):
+        run_command.run_app(first_app_config)
+
+    # The ADB wrapper wasn't even created
+    run_command.mock_adb.assert_not_called()

--- a/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
+++ b/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from briefcase.commands.base import BaseCommand
-from briefcase.exceptions import BriefcaseCommandError
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.platforms.iOS.xcode import iOSXcodeMixin
 
 
@@ -126,7 +126,7 @@ def test_invalid_explicit_device_udid(dummy_command):
     }
 
     # The user nominates a specific device that doesn't exist
-    with pytest.raises(BriefcaseCommandError):
+    with pytest.raises(InvalidDeviceError):
         dummy_command.select_target_device('deadbeef-dead-beef-cafe-deadbeefdead')
 
     # User input was not solicited
@@ -145,7 +145,7 @@ def test_invalid_explicit_device_name(dummy_command):
     }
 
     # The user nominates a specific device name that doesn't exist
-    with pytest.raises(BriefcaseCommandError):
+    with pytest.raises(InvalidDeviceError):
         dummy_command.select_target_device('iphone 99')
 
     # User input was not solicited
@@ -165,7 +165,7 @@ def test_invalid_explicit_device_name_and_version(dummy_command):
 
     # The user nominates a valid device name, but on a version that
     # doesn't exist.
-    with pytest.raises(BriefcaseCommandError):
+    with pytest.raises(InvalidDeviceError):
         dummy_command.select_target_device('iphone 11::37.42')
 
 


### PR DESCRIPTION
This user provides the user with a list of available devices if they don't specify the `-d` option to `android run`.

The device list contains:
* All physical devices (including unauthorized devices)
* All emulators (running and idle)
* A "create new emulator" option.

The following behavioral changes have been made:
 * The semantics of `run android -d` have been modified to accept device IDs (in both the hexstring physical device names and `emulator-5554` format), as well as the `@robotFriend` format for specifying emulators.

* The value provided to `-d` is validated. If the provided value isn't a valid ID or AVD, an error is raised.

* If the provided device ID points at a device that hasn't been authorized for developer activity, an error is raised that provides a link to the official Android documentation on how to enable developer mode.

* If the emulator is not running, an error is raised providing details on how to start the device. Automating this is left as future work.

* If the user selects a completely new device, an error is raised with basic instructions on how to create a new emulator. Automating this is left as future work.
